### PR TITLE
Add support for hidden files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ It's purpose is to create single page HTML+Javascript browsable lists of the con
 ## Usage
 The program only takes two arguments by default (the program will ignore those hidden files, which start with a `.` in Linux file system), the directory to be indexed and the output file name without the extension, so:
 
- *diogeneslist.py /home/user filelist*
+```shell
+python diogeneslist.py /home/user filelist
+```
  
 Will index the contents of /home/user and save them to filelist.html on the current directory. Simple as that
 
 if you want to show the hidden files in the index, you can use the following command:
 
- *diogeneslist.py /home/user filelist True*
+```shell
+python diogeneslist.py /home/user filelist True
+```
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ DiogenesList is a multiplatform CLI-only clone of [Snap2HTML](http://www.rlvisio
 It's purpose is to create single page HTML+Javascript browsable lists of the contents of a given directory
 
 ## Usage
-The program only takes two arguments, the directory to be indexed and the output file name without the extension, so:
+The program only takes two arguments by default (the program will ignore those hidden files, which start with a `.` in Linux file system), the directory to be indexed and the output file name without the extension, so:
 
  *diogeneslist.py /home/user filelist*
  
 Will index the contents of /home/user and save them to filelist.html on the current directory. Simple as that
+
+if you want to show the hidden files in the index, you can use the following command:
+
+ *diogeneslist.py /home/user filelist True*
 
 
 ## License


### PR DESCRIPTION
The program is now set to hide the hidden files by default. With an additional boolean argument, hidden files will appear in the index again.

## Usage
The program only takes two arguments by default (the program will ignore those hidden files, which start with a `.` in Linux file system), the directory to be indexed and the output file name without the extension, so:

```shell
python diogeneslist.py /home/user filelist
```
 
Will index the contents of /home/user and save them to filelist.html on the current directory. Simple as that

if you want to show the hidden files in the index, you can use the following command:

```shell
python diogeneslist.py /home/user filelist True
```